### PR TITLE
Name in contrast to RDP implementation

### DIFF
--- a/parallel.cpp
+++ b/parallel.cpp
@@ -131,6 +131,9 @@ extern "C"
 		if (APIVersion != NULL)
 			*APIVersion = RSP_PLUGIN_API_VERSION;
 
+		if (PluginNamePtr != NULL)
+			*PluginNamePtr = "paraLLEl-RSP";
+
 		if (Capabilities != NULL)
 			*Capabilities = 0;
 


### PR DESCRIPTION
This is what I see from `mupen64plus-ui-console` without this change:
`UI-Console: using RSP plugin: '(null)' v0.1.1`

[paraLLEl-RDP](https://github.com/libretro/parallel-n64/blob/2b519aad1cc2f60aadcc82d0e096b8bd5358b7e3/mupen64plus-video-paraLLEl/parallel.cpp#L109)
