### PR TITLE
Fix building on Fedora 33

### DIFF
--- a/parallel.cpp
+++ b/parallel.cpp
@@ -3,6 +3,7 @@
 #else
 #include "rsp_jit.hpp"
 #endif
+#include <stdarg.h>
 #include <stdint.h>
 
 #include "m64p_plugin.h"


### PR DESCRIPTION
The build was failing due to undefined references to va_start and va_end